### PR TITLE
Causing the marker on the ground to blink very fast

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -116,7 +116,7 @@ end)
 -- Display markers
 Citizen.CreateThread(function()
 	while true do
-		Citizen.Wait(10)
+		Citizen.Wait(0)
 		local coords = GetEntityCoords(GetPlayerPed(-1))
 
 		for k,v in pairs(Config.Zones) do


### PR DESCRIPTION
This will fix the issue with the ground marker blinking very fast needs to be ran every frame